### PR TITLE
support for js File array in the model of a <input type="file">

### DIFF
--- a/src/directives/model/default.js
+++ b/src/directives/model/default.js
@@ -6,9 +6,12 @@ module.exports = {
     var self = this
     var el = this.el
 
+    // - type='file' passses the File array into the model
+    var file = el.type == "file"
+
     // check params
-    // - lazy: update model on "change" instead of "input"
-    var lazy = this._checkParam('lazy') != null
+    // - lazy: update model on "change" instead of "input". Also do this for type='file'.
+    var lazy = this._checkParam('lazy') != null || file
     // - number: cast value into number when updating model.
     var number = this._checkParam('number') != null
 
@@ -31,7 +34,7 @@ module.exports = {
     // shared setter
     function set () {
       self.set(
-        number ? _.toNumber(el.value) : el.value,
+        file ? el.files : ( number ? _.toNumber(el.value) : el.value ),
         true
       )
     }


### PR DESCRIPTION
The input type='file' doesnt have a element.value like the rest of the inputs, and it pretty much always operates like a lazy input.

All this change does is make the model populated by the element's File array in element.files, so then you can use FileReader or whatever else to get the contents of the file that was marked for uploading, including it's size and filename and path.