### PR TITLE
support jQuery change event

### DIFF
--- a/src/directives/model/default.js
+++ b/src/directives/model/default.js
@@ -79,6 +79,9 @@ module.exports = {
 
     this.event = lazy ? 'change' : 'input'
     _.on(el, this.event, this.listener)
+    if (typeof(jQuery) === 'function') {
+      jQuery(el).on('change', this.listener)
+    }
 
     // IE9 doesn't fire input event on backspace/del/cut
     if (!lazy && _.isIE9) {


### PR DESCRIPTION
jQuery have a lot of UI components，such as bootstrap-datepicker, select2, these components will change value of form control and won't trigger native change event. instead of,  these components trigger a internal jQuery change event, so we can listen jQuery change event in Vue for ViewModel