### PR TITLE
Return empty string for Infinity and properly format values such as 0.999

### DIFF
--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -61,14 +61,15 @@ var digitsRE = /(\d{3})(?=\d)/g
 
 exports.currency = function (value, sign) {
   value = parseFloat(value)
-  if (!value && value !== 0) return ''
+  if (!isFinite(value) || (!value && value !== 0)) return ''
   sign = sign || '$'
   var s = Math.floor(Math.abs(value)).toString(),
     i = s.length % 3,
     h = i > 0
       ? (s.slice(0, i) + (s.length > 3 ? ',' : ''))
       : '',
-    f = '.' + value.toFixed(2).slice(-2)
+	v = Math.abs(parseInt((value * 100) % 100, 10)),
+    f = '.' + (v < 10 ? ('0' + v) : v)
   return (value < 0 ? '-' : '') +
     sign + h + s.slice(i).replace(digitsRE, '$1,') + f
 }

--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -68,7 +68,7 @@ exports.currency = function (value, sign) {
     h = i > 0
       ? (s.slice(0, i) + (s.length > 3 ? ',' : ''))
       : '',
-	v = Math.abs(parseInt((value * 100) % 100, 10)),
+    v = Math.abs(parseInt((value * 100) % 100, 10)),
     f = '.' + (v < 10 ? ('0' + v) : v)
   return (value < 0 ? '-' : '') +
     sign + h + s.slice(i).replace(digitsRE, '$1,') + f

--- a/test/unit/specs/filters/filters_spec.js
+++ b/test/unit/specs/filters/filters_spec.js
@@ -62,13 +62,15 @@ describe('Filters', function () {
     expect(filter(1234)).toBe('$1,234.00')
     expect(filter(1234.45)).toBe('$1,234.45')
     expect(filter(123443434.4343434)).toBe('$123,443,434.43')
+    expect(filter(0.99999)).toBe('$0.99')
     // sign arg
     expect(filter(2134, '@')).toBe('@2,134.00')
-    // falsy and 0
+    // falsy, infinity and 0
     expect(filter(0)).toBe('$0.00')
     expect(filter(false)).toBe('')
     expect(filter(null)).toBe('')
     expect(filter(undefined)).toBe('')
+    expect(filter(Infinity)).toBe('')
     // negative numbers
     expect(filter(-50)).toBe('-$50.00')
     expect(filter(-150.43)).toBe('-$150.43')


### PR DESCRIPTION
This PR fixes two issues in currency filter (demo for both: http://jsfiddle.net/k5bv3r62/ ):

1) x.999 values are shown as $x.00
Say you have model with value 0.999. With currency filter applied it will be shown as $0.00

2) Infinity value show as $In,finity.ty
I think, it would be good to return empty string as for falsy values

Also I added new test cases for described issues.