### PR TITLE
make example of vm ready bug in phantom.js

### DIFF
--- a/examples/nested/index.html
+++ b/examples/nested/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Vue.js nested demo</title>
+    <script src="../../dist/vue.js"></script>
+  </head>
+  <body>
+
+    <!-- item template -->
+    <script type="text/x-template" id="child-template">
+      <span class="three" v-text="state.created"></span>
+      <span class="four" v-text="state.ready"></span>
+    </script>
+
+    <!-- the demo root element -->
+    <div id="demo">
+      <span class="one" v-text="state.created"></span>
+      <span class="two" v-text="state.ready"></span>
+
+      <div v-component="child">
+      </div>
+    </div>
+
+    <!-- demo code -->
+    <script src="nested.js"></script>
+  </body>
+</html>

--- a/examples/nested/nested.js
+++ b/examples/nested/nested.js
@@ -1,0 +1,35 @@
+// define the child component
+Vue.component('child', {
+  template: '#child-template',
+  data: function () {
+    return {
+      state: {
+        created: false,
+        ready: false
+      }
+    }
+  },
+  created: function() {
+    this.state.created = true
+  },
+  ready: function() {
+    this.state.ready = true
+  }
+})
+
+// boot up the demo
+var parent = new Vue({
+  el: '#demo',
+  data: {
+    state: {
+      created: false,
+      ready: false
+    }
+  },
+  created: function() {
+    this.state.created = true
+  },
+  ready: function() {
+    this.state.ready = true
+  }
+})

--- a/test/e2e/nested.js
+++ b/test/e2e/nested.js
@@ -1,0 +1,15 @@
+casper.test.begin('nested', 5, function (test) {
+  casper
+  .start('../../examples/nested/index.html')
+  .then(function () {
+    test.assertElementCount('span', 4)
+    test.assertSelectorHasText('span.one', 'true')
+    test.assertSelectorHasText('span.two', 'true')
+    test.assertSelectorHasText('span.three', 'true')
+    test.assertSelectorHasText('span.four', 'true')
+  })
+  // run
+  .run(function () {
+    test.done()
+  })
+})


### PR DESCRIPTION
@yyx990803 this doesn't seem to be a bug in the browser, but from phantom.js. I would expect the ready function for a child component to fire when running in phantom / casper, but it seems that it is not. I think the culprit is util.inDoc returning false. So maybe the version of webkit that phantom / casper use doesn't support document.documentElement.contains (at least for comments)?

One thing to note is that I am using windows...

overriding util.inDoc with $.contains seems to fix it. I'm gonna try to find a better way though.