### PR TITLE
Allow isReserved() to handle numeric inputs

### DIFF
--- a/src/util/lang.js
+++ b/src/util/lang.js
@@ -6,10 +6,7 @@
  */
 
 exports.isReserved = function (str) {
-  if(typeof str == 'number') {
-    return false;
-  }
-  var c = str.charCodeAt(0)
+  var c = (str + '').charCodeAt(0)
   return c === 0x24 || c === 0x5F
 }
 

--- a/src/util/lang.js
+++ b/src/util/lang.js
@@ -6,6 +6,9 @@
  */
 
 exports.isReserved = function (str) {
+  if(typeof str == 'number') {
+    return false;
+  }
   var c = str.charCodeAt(0)
   return c === 0x24 || c === 0x5F
 }


### PR DESCRIPTION
Currently, when an object has numeric keys and you try to $add or $delete any of those keys, an error is thrown since isReserved is expecting a string.  If this function is allowed to return false when a numeric key is passed to it, the delete operation works as expected.