### PR TITLE
Allow isReserved() to handle non-string inputs

### DIFF
--- a/src/util/lang.js
+++ b/src/util/lang.js
@@ -6,7 +6,7 @@
  */
 
 exports.isReserved = function (str) {
-  var c = str.charCodeAt(0)
+  var c = (str + '').charCodeAt(0)
   return c === 0x24 || c === 0x5F
 }
 


### PR DESCRIPTION
Carried over from #772 - change made on dev branch as requested.