### PR TITLE
let v-events accept statements

### DIFF
--- a/src/directives/events.js
+++ b/src/directives/events.js
@@ -1,6 +1,8 @@
 var _ = require('../util')
 
-module.exports = { 
+module.exports = {
+
+  acceptStatement: true,
 
   bind: function () {
     var child = this.el.__vue__
@@ -11,14 +13,21 @@ module.exports = {
       )
       return
     }
-    var method = this.vm[this.expression]
-    if (!method) {
+  },
+
+  update: function (handler, oldHandler) {
+    if (typeof handler !== 'function') {
       _.warn(
-        '`v-events` cannot find method "' + this.expression +
-        '" on the parent instance.'
+        'Directive "v-events:' + this.expression + '" ' +
+        'expects a function value.'
       )
+      return
     }
-    child.$on(this.arg, method)
+    var child = this.el.__vue__
+    if (oldHandler) {
+      child.$off(this.arg, oldHandler)
+    }
+    child.$on(this.arg, handler)
   }
 
   // when child is destroyed, all events are turned off,

--- a/test/unit/specs/directives/events_spec.js
+++ b/test/unit/specs/directives/events_spec.js
@@ -59,15 +59,35 @@ if (_.inBrowser) {
       expect(spy).not.toHaveBeenCalled()
     })
 
-    it('should warn when method not found on parent', function () {
-      new Vue({
+    it('should warn on non-function values', function () {
+      var vm = new Vue({
         el: el,
+        data: { test: 123 },
         template: '<div v-component="test" v-events="test:test"></div>',
         components: {
           test: {}
         }
       })
       expect(_.warn).toHaveBeenCalled()
+    })
+
+    it('should accept inline statement', function (done) {
+      var vm = new Vue({
+        el: el,
+        data: {a:1},
+        template: '<div v-component="test" v-events="test:a++"></div>',
+        components: {
+          test: {
+            compiled: function () {
+              this.$emit('test')
+            }
+          }
+        }
+      })
+      _.nextTick(function () {
+        expect(vm.a).toBe(2)
+        done()
+      })
     })
 
   })


### PR DESCRIPTION
This is a tentative implementation... It allows to use metaproperties like $index, $key in the handler without the child vm having to know about them.
