### PR TITLE
Prevent unused variable warning from all linters

### DIFF
--- a/src/transition/css.js
+++ b/src/transition/css.js
@@ -39,11 +39,12 @@ function push (el, dir, op, cls, cb) {
  */
 
 function flush () {
-  /* jshint unused: false */
   var f = document.documentElement.offsetHeight
   queue.forEach(run)
   queue = []
   queued = false
+  /* dummy return, so js linters don't complain about unused variable f */
+  return f
 }
 
 /**


### PR DESCRIPTION
jshint is not the only js linter, I got warnings from UglifyJS for example.