### PR TITLE
Support `disabled` attribute on select options

### DIFF
--- a/src/directives/model/select.js
+++ b/src/directives/model/select.js
@@ -107,6 +107,9 @@ function buildOptions (parent, options) {
       } else {
         el.text = op.text
         el.value = op.value
+        if (op.disabled) {
+          el.disabled = true
+        }
       }
     } else {
       el = document.createElement('optgroup')

--- a/test/unit/specs/directives/model_spec.js
+++ b/test/unit/specs/directives/model_spec.js
@@ -245,6 +245,7 @@ if (_.inBrowser) {
         data: {
           test: 'b',
           opts: [
+            { text: 'Select an option', value: null, disabled: true },
             { text: 'A', value: 'a' },
             { text: 'B', value: 'b' }
           ]
@@ -252,12 +253,15 @@ if (_.inBrowser) {
         template: '<select v-model="test" options="opts"></select>'
       })
       expect(el.firstChild.innerHTML).toBe(
+        '<option disabled="">Select an option</option>' +
         '<option value="a">A</option>' +
         '<option value="b">B</option>'
       )
       var opts = el.firstChild.options
+      expect(opts[0].disabled).toBe(true)
       expect(opts[0].selected).toBe(false)
-      expect(opts[1].selected).toBe(true)
+      expect(opts[1].selected).toBe(false)
+      expect(opts[2].selected).toBe(true)
     })
 
     it('select + options + optgroup', function () {


### PR DESCRIPTION
This PR adds support for an optional `disabled` setting in an `options` array for dynamic `<select>` elements.

Local tests ran fine, but Saucelabs choked so I wasn't able to test full browser compatibility. I'm worried that the `disabled=""` test isn't going to be consistent across browsers.