### PR TITLE
v-repeat does not completely teardown when reduced in length

### DIFF
--- a/src/instance/compile.js
+++ b/src/instance/compile.js
@@ -140,6 +140,9 @@ exports._destroy = function (remove, deferCleanup) {
   }
   // teardown all directives. this also tearsdown all
   // directive-owned watchers.
+  for (i = 0; i < this._directives.length; i++) {
+    this._directives[i]._teardown()
+  }
   if (this._unlinkFn) {
     this._unlinkFn()
   }

--- a/test/unit/specs/directives/repeat_spec.js
+++ b/test/unit/specs/directives/repeat_spec.js
@@ -713,6 +713,34 @@ if (_.inBrowser) {
       })
     })
 
+    it('should teardown unused portion', function (done) {
+      var vm = new Vue({
+        el: el,
+        template: '<ul><component is="item" v-repeat="items" count="{{count}}"></component></ul>',
+        data: {
+            count: 0,
+            items:  [1, 2]
+        },
+        components: {
+          item: {
+            replace: true,
+            props: ['count'],
+            template: '<li>{{ $value }}{{ count }}</li>',
+          }
+        }
+      })
+      vm.items = [1]
+      _.nextTick(function () {
+        expect(function () {
+          vm.count = 1
+        }).not.toThrow()
+        _.nextTick(function () {
+          expect(el.innerHTML).toBe('<ul><li>11</li></ul>')
+          done()
+        })
+      })
+    })
+
   })
 }
 


### PR DESCRIPTION
In the latest dev branch, I ran into an issue with assigning new values to `props` used by a `component` after its associated list of items in `v-repeat` has reduced in length.

It appears that some expired items are still watching for changes; they try to set `undefined[prop]` and fail. 

JSFiddle: http://jsfiddle.net/alchen/42ht4eg0/
