### PR TITLE
Cater for possibility of el not existing

### DIFF
--- a/src/directives/repeat.js
+++ b/src/directives/repeat.js
@@ -683,9 +683,7 @@ module.exports = {
 
 function findPrevVm (vm, anchor, id) {
   var el = vm.$el.previousSibling
-  if (!el) {
-      return
-  }
+  if (!el) return
   while (
     (!el.__vue__ || el.__vue__.$options._repeatId !== id) &&
     el !== anchor

--- a/src/directives/repeat.js
+++ b/src/directives/repeat.js
@@ -684,7 +684,7 @@ module.exports = {
 function findPrevVm (vm, anchor, id) {
   var el = vm.$el.previousSibling
   if (!el) {
-      return {}
+      return
   }
   while (
     (!el.__vue__ || el.__vue__.$options._repeatId !== id) &&

--- a/src/directives/repeat.js
+++ b/src/directives/repeat.js
@@ -683,6 +683,9 @@ module.exports = {
 
 function findPrevVm (vm, anchor, id) {
   var el = vm.$el.previousSibling
+  if (!el) {
+      return {}
+  }
   while (
     (!el.__vue__ || el.__vue__.$options._repeatId !== id) &&
     el !== anchor


### PR DESCRIPTION
While writing a drag and drop vue sortable directive which uses jQuery UI sortable (both same list and connected list sortable), I found vue was throwing `el` undefined errors a lot with various actions, e.g. dragging the first item in a list then updating the underlying array model. The element had been removed by jQuery while vue was expecting it to exist.

By checking for the existance of `el`, and returning and empty object if it does not exist, allow these two dom manipulation libraries play nicely together.