### PR TITLE
New filter: `prevent`

### DIFF
--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -139,6 +139,17 @@ exports.debounce = function (handler, delay) {
 }
 
 /**
+ * Prevent event default behavior
+ */
+exports.prevent = function (handler) {
+  if (!handler) return;
+  return function (e) {
+    e.preventDefault()
+    return handler.call(this, e)
+  }
+}
+
+/**
  * Install special array filters
  */
 

--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -142,9 +142,11 @@ exports.debounce = function (handler, delay) {
  * Prevent event default behavior
  */
 exports.prevent = function (handler) {
-  if (!handler) return;
+  if (!handler) return
   return function (e) {
-    e.preventDefault()
+    if (e) {
+      e.preventDefault()
+    }
     return handler.call(this, e)
   }
 }

--- a/test/unit/specs/filters/filters_spec.js
+++ b/test/unit/specs/filters/filters_spec.js
@@ -123,6 +123,15 @@ describe('Filters', function () {
     }, 500)
   })
 
+  it('prevent', function (done) {
+    var filter = filters.prevent
+    expect(filter(null)).toBeUndefined()
+    var spy = jasmine.createSpy('filter:prevent')
+    var handler = filter(spy)
+    handler()
+    expect(spy).toHaveBeenCalled()
+  })
+
   it('filterBy', function () {
     var filter = filters.filterBy
     var arr = [

--- a/test/unit/specs/filters/filters_spec.js
+++ b/test/unit/specs/filters/filters_spec.js
@@ -123,13 +123,18 @@ describe('Filters', function () {
     }, 500)
   })
 
-  it('prevent', function (done) {
+  it('prevent', function () {
     var filter = filters.prevent
     expect(filter(null)).toBeUndefined()
     var spy = jasmine.createSpy('filter:prevent')
     var handler = filter(spy)
     handler()
     expect(spy).toHaveBeenCalled()
+    var value = 0
+    handler({preventDefault: function () {
+      value = 1
+    }})
+    expect(value).toBe(1)
   })
 
   it('filterBy', function () {


### PR DESCRIPTION
> Prevent default event behavior.

It is useful on `<a>` link when you want to call a function instead of visiting the link:

```html
<a href="/login" v-on="click: showLogin=true | prevent">Login</a>
```

Another use case is dropdown. GitHub has a user menu dropdown on the top right. The avatar has a link of the user profile, but it won't redirect to the profile page when clicking the avatar. Instead, it will show a dropdown menu.

```html
<a href="/{{ username }}" v-on="click: showDropdown=true | prevent">avatar</a>
<dropdown show="{{@ showDropdown }}">
    ....
</dropdown>
```