### PR TITLE
fix eslint ternary operator error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -137,7 +137,7 @@
     "object-shorthand": 0,
     "one-var": [2, { "initialized": "never" }],
     "operator-assignment": 0,
-    "operator-linebreak": [2, "after"],
+    "operator-linebreak": [2, "after", { "overrides": { "?": "before", ":": "before" } }],
     "padded-blocks": 0,
     "prefer-const": 0,
     "quote-props": 0,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "casperjs": "^1.1.0-beta3",
     "codecov.io": "^0.1.2",
-    "eslint": "^1.1.0",
+    "eslint": "^1.3.1",
     "grunt": "^0.4.5",
     "grunt-eslint": "^17.1.0",
     "grunt-karma": "^0.12.0",

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -96,8 +96,8 @@ Watcher.prototype.get = function () {
         'Error when evaluating expression "' +
         this.expression + '". ' +
         (config.debug
-          ? '' :
-          'Turn on debug mode to see stack trace.'
+          ? ''
+          : 'Turn on debug mode to see stack trace.'
         ), e
       )
     }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -147,7 +147,7 @@
     "object-shorthand": 0,
     "one-var": [2, { "initialized": "never" }],
     "operator-assignment": 0,
-    "operator-linebreak": [2, "after"],
+    "operator-linebreak": [2, "after", { "overrides": { "?": "before", ":": "before" } }],
     "padded-blocks": 0,
     "prefer-const": 0,
     "quote-props": 0,


### PR DESCRIPTION
eslint's operator-linebreak rule now supports the ternary operator (https://github.com/eslint/eslint/issues/3274).

Changed the rule to match the code, and fixed the single instance
in the code that was different.