### PR TITLE
Add mixed type properties.

### DIFF
--- a/src/compiler/compile-props.js
+++ b/src/compiler/compile-props.js
@@ -139,13 +139,7 @@ function makePropsLinkFn (props) {
       } else {
         // literal, cast it and just set once
         var raw = prop.raw
-        value = options.type === Boolean && raw === ''
-          ? true
-          // do not cast emptry string.
-          // _.toNumber casts empty string to 0.
-          : raw.trim()
-            ? _.toBoolean(_.toNumber(raw))
-            : raw
+        value = _.castProp(prop, raw)
         _.initProp(vm, prop, value)
       }
     }
@@ -160,12 +154,13 @@ function makePropsLinkFn (props) {
  */
 
 function getDefault (options) {
+  var types = _.normalizePropTypes(options.type)
   // no default, return undefined
   if (!options.hasOwnProperty('default')) {
     // absent boolean value defaults to false
-    return options.type === Boolean
-      ? false
-      : undefined
+    return types && types.length === 1 && types[0] === Boolean
+        ? false
+        : undefined
   }
   var def = options.default
   // warn against non-factory defaults for Object & Array
@@ -177,7 +172,7 @@ function getDefault (options) {
     )
   }
   // call factory function for non-Function types
-  return typeof def === 'function' && options.type !== Function
+  return typeof def === 'function' && !(types && types.length === 1 && types[0] === Function)
     ? def()
     : def
 }

--- a/src/util/component.js
+++ b/src/util/component.js
@@ -52,10 +52,50 @@ exports.initProp = function (vm, prop, value) {
 }
 
 /**
+ * Automatically cast a prop based on its specified type.
+ *
+ * @param {Object} prop
+ * @param {String} raw
+ * @return {String|Boolean|Number}
+ */
+exports.castProp = function (prop, raw) {
+  var hasBoolean = false
+  var hasNumber = false
+  var types = exports.normalizePropTypes(prop.options.type)
+  if (types) {
+    var i, l
+    for (i = 0, l = types.length; i < l; i++) {
+      var type = types[i]
+      if (type === Number) {
+        hasNumber = true
+      } else if (type === Boolean) {
+        hasBoolean = true
+      }
+    }
+  }
+
+  if (hasBoolean && raw === '') {
+    return true
+  }
+  var value = raw
+  if (!value.trim()) {
+    return value
+  }
+  if (!types || hasNumber) {
+    value = _.toNumber(value)
+  }
+  if (!types || hasBoolean) {
+    value = _.toBoolean(value)
+  }
+  return value
+}
+
+/**
  * Assert whether a prop is valid.
  *
  * @param {Object} prop
  * @param {*} value
+ * @return {Boolean}
  */
 
 exports.assertProp = function (prop, value) {
@@ -65,37 +105,48 @@ exports.assertProp = function (prop, value) {
     return true
   }
   var options = prop.options
-  var type = options.type
+  var types = exports.normalizePropTypes(options.type)
   var valid = true
-  var expectedType
-  if (type) {
-    if (type === String) {
-      expectedType = 'string'
-      valid = typeof value === expectedType
-    } else if (type === Number) {
-      expectedType = 'number'
-      valid = typeof value === 'number'
-    } else if (type === Boolean) {
-      expectedType = 'boolean'
-      valid = typeof value === 'boolean'
-    } else if (type === Function) {
-      expectedType = 'function'
-      valid = typeof value === 'function'
-    } else if (type === Object) {
-      expectedType = 'object'
-      valid = _.isPlainObject(value)
-    } else if (type === Array) {
-      expectedType = 'array'
-      valid = _.isArray(value)
-    } else {
-      valid = value instanceof type
+  var expectedTypes = []
+  if (types) {
+    valid = false
+    var i, l, v, expectedType
+    for (i = 0, l = types.length; i < l; i++) {
+      var type = types[i]
+      if (type === String) {
+        expectedType = 'string'
+        v = typeof value === expectedType
+      } else if (type === Number) {
+        expectedType = 'number'
+        v = typeof value === 'number'
+      } else if (type === Boolean) {
+        expectedType = 'boolean'
+        v = typeof value === 'boolean'
+      } else if (type === Function) {
+        expectedType = 'function'
+        v = typeof value === 'function'
+      } else if (type === Object) {
+        expectedType = 'object'
+        v = _.isPlainObject(value)
+      } else if (type === Array) {
+        expectedType = 'array'
+        v = _.isArray(value)
+      } else {
+        expectedType = null
+        v = value instanceof type
+      }
+      expectedTypes.push(expectedType)
+      if (v) {
+        valid = true
+        break
+      }
     }
   }
   if (!valid) {
     process.env.NODE_ENV !== 'production' && _.warn(
       'Invalid prop: type check failed for ' +
       prop.path + '="' + prop.raw + '".' +
-      ' Expected ' + formatType(expectedType) +
+      ' Expected ' + formatType(expectedTypes) +
       ', got ' + formatValue(value) + '.'
     )
     return false
@@ -113,10 +164,35 @@ exports.assertProp = function (prop, value) {
   return true
 }
 
+/**
+ * Normalize property type option.
+ * The returned value will either be an array of types,
+ * or null if the property has no type
+ *
+ * @param {*} types
+ * @return {Array|null}
+ */
+exports.normalizePropTypes = function (types) {
+  if (!types) {
+    return null
+  }
+  if (!_.isArray(types)) {
+    types = [types]
+  }
+  return types.length ? types : null
+}
+
 function formatType (val) {
-  return val
-    ? val.charAt(0).toUpperCase() + val.slice(1)
-    : 'custom type'
+  for (var i = 0, l = val.length; i < l; i++) {
+    val[i] = val[i]
+      ? val[i].charAt(0).toUpperCase() + val[i].slice(1)
+      : 'custom type'
+  }
+  if (val.length === 1) {
+    return val[0]
+  } else {
+    return 'one of ' + val.join(', ')
+  }
 }
 
 function formatValue (val) {


### PR DESCRIPTION
Literal property auto-casting now respects property type(s),
and will not cast a property to boolean or number if it
cannot be a boolean or number.

Fixes #1284, #1148 

There were a few special cases that are a bit different for mixed types, but it should be backwards compatible:
* `default` will always be called even if one of the types is `Function`. But if the only type is `Function`, it won't be called, like before. In practice it probably doesn't makes sense to have a property that can be either a Function or something else.
* If the default is not specified and the property is omitted, the default is undefined, except for Boolean, where it is false. For a mixed type, the default will be undefined even if one of the possible types is Boolean. It might make sense to use false as the default here, but in practice both are falsy, and you can specify a default, so it's not a big issue.
* In contrast to the previous point, if one of the possible types is Boolean (explicitly specified), and the attribute value is omitted (or is an empty string), it will be cast to true, even if String is also an accepted type for the property. This is how it worked previously for Boolean type properties, so I extended that to mixed properties that include Boolean. It made more sense for a property without a value to be true in this case, instead of a falsy empty string.

For example:
```
prop1: [Boolean, String]
prop2: String

<example></example> <!-- undefined undefined -->
<example prop1 prop2></example> <!-- true, '' -->
<example prop1="foo" prop2="foo"></example> <!-- 'foo' 'foo' -->
<example prop1="123" prop2="123"></example> <!-- '123' '123' -->
```