### PR TITLE
Return if no previous sibling of el

### DIFF
--- a/dist/vue.js
+++ b/dist/vue.js
@@ -9057,6 +9057,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    el !== anchor
 	  ) {
 	    el = el.previousSibling
+	    if (!el) return
 	    frag = el.__vfrag__
 	  }
 	  return frag

--- a/dist/vue.js
+++ b/dist/vue.js
@@ -9057,7 +9057,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	    el !== anchor
 	  ) {
 	    el = el.previousSibling
-	    if (!el) return
 	    frag = el.__vfrag__
 	  }
 	  return frag

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -548,6 +548,7 @@ function findPrevFrag (frag, anchor, id) {
     el !== anchor
   ) {
     el = el.previousSibling
+    if (!el) return
     frag = el.__vfrag__
   }
   return frag

--- a/src/directives/repeat.js
+++ b/src/directives/repeat.js
@@ -729,7 +729,6 @@ function findPrevVm (vm, anchor, id) {
     el !== anchor
   ) {
     el = el.previousSibling
-    if (!el) return
   }
   return el.__vue__
 }

--- a/src/directives/repeat.js
+++ b/src/directives/repeat.js
@@ -729,6 +729,7 @@ function findPrevVm (vm, anchor, id) {
     el !== anchor
   ) {
     el = el.previousSibling
+    if (!el) return
   }
   return el.__vue__
 }


### PR DESCRIPTION
Cater for scenario where there is no previous sibling of el. Solution to #1249 and similar to #982. Occurs in scenario where dragging between lists using library like RubaXa Sortable. 