### PR TITLE
Return if no previousSibling of el found

### DIFF
--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -548,6 +548,7 @@ function findPrevFrag (frag, anchor, id) {
     el !== anchor
   ) {
     el = el.previousSibling
+    if (!el) return
     frag = el.__vfrag__
   }
   return frag


### PR DESCRIPTION
Cater for scenario where there is no previous sibling of el. Solution to #1249 and similar to #982. Occurs when dragging between lists using a drag and drop library such as RubaXa Sortable.