### PR TITLE
support for option merge strategies

### DIFF
--- a/src/util/options.js
+++ b/src/util/options.js
@@ -14,7 +14,7 @@ var extend = _.extend
  * @param {Vue} [vm]
  */
 
-var strats = Object.create(null)
+var strats = config.optionMergeStrategies = Object.create(null)
 
 /**
  * Helper that recursively merges two data objects together.


### PR DESCRIPTION
See the following issue.
https://github.com/yyx990803/vue/issues/1271

Option merge strategies is supported for `1.0.0-alpha` and `1.0.0-beta` branch.
I think that vue.js need to support option merge strategies for 0.12 latest version.
Because the following issues that cannot pass plugin configration has occurred in vue-validator.

https://github.com/vuejs/vue-validator/issues/55
https://github.com/vuejs/vue-validator/issues/57

I hope you will consider that.