### PR TITLE
allow optional `(key,val) in arr` syntax for `v-for`

### DIFF
--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -14,7 +14,13 @@ module.exports = {
     // support "item in items" syntax
     var inMatch = this.expression.match(/(.*) in (.*)/)
     if (inMatch) {
-      this.alias = inMatch[1]
+      var itMatch = inMatch[1].match(/\((.*),(.*)\)/)
+      if (itMatch) {
+        this.iterator = itMatch[1]
+        this.alias = itMatch[2]
+      } else {
+        this.alias = inMatch[1]
+      }
       this._watcherExp = inMatch[2]
     }
 
@@ -215,6 +221,9 @@ module.exports = {
     } else if (scope.$key) {
       // avoid accidental fallback
       _.define(scope, '$key', null)
+    }
+    if (this.iterator) {
+      _.defineReactive(scope, this.iterator, key || index)
     }
     var frag = this.factory.create(host, scope, this._frag)
     frag.forId = this.id

--- a/test/unit/specs/directives/for/for_spec.js
+++ b/test/unit/specs/directives/for/for_spec.js
@@ -595,6 +595,39 @@ if (_.inBrowser) {
       expect(hasWarned(_, 'Duplicate value')).toBe(true)
     })
 
+    it('key val syntax with object', function () {
+      new Vue({
+        el: el,
+        template: '<div v-for="(key,val) in items">{{key}} {{val}}</div>',
+        data: {
+          items: {'a': 'x'}
+        }
+      })
+      expect(el.innerHTML).toBe('<div>a x</div>')
+    })
+
+    it('key val syntax with array', function () {
+      new Vue({
+        el: el,
+        template: '<div v-for="(ind,val) in items">{{ind}} {{val}}</div>',
+        data: {
+          items: ['x', 'y']
+        }
+      })
+      expect(el.innerHTML).toBe('<div>0 x</div><div>1 y</div>')
+    })
+
+    it('key val syntax with nested v-for s', function () {
+      new Vue({
+        el: el,
+        template: '<div v-for="(key,val) in items"><div v-for="(subkey,subval) in val">{{key}} {{subkey}} {{subval}}</div></div>',
+        data: {
+          items: {'a': {'b': 'c'}}
+        }
+      })
+      expect(el.innerHTML).toBe('<div><div>a b c</div></div>')
+    })
+
     it('repeat number', function () {
       new Vue({
         el: el,


### PR DESCRIPTION
optionally binding the iteration index (or key when iterating over an
object) to a name to simplify work with nested `v-for`s